### PR TITLE
add post_url function -- use SSL and some attempts to make parsing more reliable

### DIFF
--- a/adafruit_espatcontrol.py
+++ b/adafruit_espatcontrol.py
@@ -124,8 +124,11 @@ class ESP_ATcontrol:
         port = 80
         if ssl:
             port = 443
-        if not self.connect(self.TYPE_TCP, domain, port, keepalive=10, retries=3):
-            raise RuntimeError("Failed to connect to host")
+            if not self.connect(self.TYPE_SSL, domain, port, keepalive=10, retries=3):
+                raise RuntimeError("Failed to connect to host")
+        else:
+            if not self.connect(self.TYPE_TCP, domain, port, keepalive=10, retries=3):
+                raise RuntimeError("Failed to connect to host")
         request = "GET "+path+" HTTP/1.1\r\nHost: "+domain+"\r\n\r\n"
         try:
             self.send(bytes(request, 'utf-8'))
@@ -158,8 +161,11 @@ class ESP_ATcontrol:
         port = 80
         if ssl:
             port = 443
-        if not self.connect(self.TYPE_TCP, domain, port, keepalive=10, retries=3):
-            raise RuntimeError("Failed to connect to host")
+            if not self.connect(self.TYPE_SSL, domain, port, keepalive=10, retries=3):
+                raise RuntimeError("Failed to connect to host")
+        else:
+            if not self.connect(self.TYPE_TCP, domain, port, keepalive=10, retries=3):
+                raise RuntimeError("Failed to connect to host")
         request = "POST "+path+" HTTP/1.1\r\nHost: "+domain+"\r\n\r\n"
         try:
             self.send(bytes(request, 'utf-8'))

--- a/examples/espatcontrol_post_simpletest.py
+++ b/examples/espatcontrol_post_simpletest.py
@@ -1,0 +1,45 @@
+import time
+import board
+import busio
+from digitalio import DigitalInOut
+import adafruit_espatcontrol
+
+MY_SSID = "yourssid"
+MY_PASS = "yourpassword"
+
+URL = "http://io.adafruit.com/api/v2/webhooks/feed/<YOURWEBHOOK>?value="
+
+RX = board.ESP_TX
+TX = board.ESP_RX
+resetpin = DigitalInOut(board.ESP_WIFI_EN)
+
+
+uart = busio.UART(TX, RX, baudrate=115200, timeout=0.1)
+#uart.baudrate=9600
+print("Get a URL:", URL)
+
+esp = adafruit_espatcontrol.ESP_ATcontrol(uart, 115200, reset_pin=resetpin, debug=True)
+print("Connected to AT software version", esp.get_version())
+counter = 0 
+while True:
+    try:
+        # Connect to WiFi if not already
+        print("Connected to", esp.remote_AP)
+        if esp.remote_AP[0] != MY_SSID:
+            esp.join_AP(MY_SSID, MY_PASS)
+            print("My IP Address:", esp.local_ip)
+        # great, lets get the data
+        print("Retrieving URL...", end='')
+        header, body = esp.post_url(URL+str(counter))
+        counter = counter + 1
+        print("OK")
+    except RuntimeError as e:
+        print("Failed to connect, retrying")
+        print(e)
+        continue
+
+    print('-'*40)
+    print(str(body, 'utf-8'))
+    print('-'*40)
+
+    time.sleep(60)


### PR DESCRIPTION
tried to make the at_response parsing of "\r\n" more reilable.
This seems to work well with the ESP32. Not so well with the ESP8266

added a post_url function to send a POST request

for request_url and post_url -- use type SSL for https.

added example for sending  POST request to adafruitIO using "webhook" for a feed.
This example is for http but I tried it for both http and https and it works
I have only tested it with an esp32 on either a Metro_m4_express or a particle_argon.
