### PR TITLE
Add pinout for Particle Argon Boards to Post Example

### DIFF
--- a/examples/espatcontrol_post.py
+++ b/examples/espatcontrol_post.py
@@ -16,11 +16,21 @@ except ImportError:
 
 URL = "https://io.adafruit.com/api/v2/webhooks/feed/"+settings['aio_feed_webhook']+"?value="
 
+# With a Metro or Feather M4
 resetpin = DigitalInOut(board.D5)
 rtspin = DigitalInOut(board.D9)
 uart = busio.UART(board.TX, board.RX, timeout=0.1)
 
-
+# With a Particle Argon
+# RX = board.ESP_TX
+# TX = board.ESP_RX
+# resetpin = DigitalInOut(board.ESP_WIFI_EN)
+# rtspin = DigitalInOut(board.ESP_CTS)
+# uart = busio.UART(TX, RX, timeout=0.1)
+# esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
+# from digitalio import Direction
+# esp_boot.direction = Direction.OUTPUT
+# esp_boot.value = True
 
 print("Post to a URL", URL)
 

--- a/examples/espatcontrol_post.py
+++ b/examples/espatcontrol_post.py
@@ -22,15 +22,17 @@ rtspin = DigitalInOut(board.D9)
 uart = busio.UART(board.TX, board.RX, timeout=0.1)
 
 # With a Particle Argon
-# RX = board.ESP_TX
-# TX = board.ESP_RX
-# resetpin = DigitalInOut(board.ESP_WIFI_EN)
-# rtspin = DigitalInOut(board.ESP_CTS)
-# uart = busio.UART(TX, RX, timeout=0.1)
-# esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
-# from digitalio import Direction
-# esp_boot.direction = Direction.OUTPUT
-# esp_boot.value = True
+"""
+RX = board.ESP_TX
+TX = board.ESP_RX
+resetpin = DigitalInOut(board.ESP_WIFI_EN)
+rtspin = DigitalInOut(board.ESP_CTS)
+uart = busio.UART(TX, RX, timeout=0.1)
+esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
+from digitalio import Direction
+esp_boot.direction = Direction.OUTPUT
+esp_boot.value = True
+"""
 
 print("Post to a URL", URL)
 


### PR DESCRIPTION
Adding pinout for Particle Argon boards to the `espatcontrol_post` example