### PR TITLE
 fixup examples

### DIFF
--- a/examples/espatcontrol_aio_post.py
+++ b/examples/espatcontrol_aio_post.py
@@ -61,7 +61,7 @@ while True:
         response.close()
         counter = counter + 1
         print("OK")
-    except (RuntimeError, adafruit_espatcontrol.OKError) as e:
+    except (ValueError, RuntimeError, adafruit_espatcontrol.OKError) as e:
         print("Failed to get data, retrying\n", e)
         continue
     response = None

--- a/examples/espatcontrol_cheerlights.py
+++ b/examples/espatcontrol_cheerlights.py
@@ -63,7 +63,7 @@ while True:
         r = requests.get(DATA_SOURCE)
         builtin[0] = (0, 0, 100)
         print("Reply is OK!")
-    except (RuntimeError, adafruit_espatcontrol.OKError) as e:
+    except (ValueError, RuntimeError, adafruit_espatcontrol.OKError) as e:
         print("Failed to get data, retrying\n", e)
         continue
     print('-'*40,)

--- a/examples/espatcontrol_countviewer.py
+++ b/examples/espatcontrol_countviewer.py
@@ -8,8 +8,8 @@ import time
 import board
 import busio
 from digitalio import DigitalInOut
-import adafruit_espatcontrol
-import adafruit_espatcontrol_requests as requests
+from adafruit_espatcontrol import adafruit_espatcontrol
+from adafruit_espatcontrol import adafruit_espatcontrol_requests as requests
 from adafruit_ht16k33 import segments
 import neopixel
 
@@ -119,7 +119,7 @@ while True:
         print("Retrieving data source...", end='')
         r = requests.get(DATA_SOURCE)
         print("Reply is OK!")
-    except (RuntimeError, adafruit_espatcontrol.OKError) as e:
+    except (ValueError, RuntimeError, adafruit_espatcontrol.OKError) as e:
         print("Failed to get data, retrying\n", e)
         continue
     #print('-'*40,)

--- a/examples/espatcontrol_quoteEPD.py
+++ b/examples/espatcontrol_quoteEPD.py
@@ -177,7 +177,7 @@ while True:
         print("Retrieving data source...", end='')
         req = requests.get(DATA_SOURCE)
         print("Reply is OK!")
-    except (RuntimeError, adafruit_espatcontrol.OKError) as e:
+    except (ValueError, RuntimeError, adafruit_espatcontrol.OKError) as e:
         print("Failed to get data, retrying\n", e)
         continue
 

--- a/examples/espatcontrol_simpletest.py
+++ b/examples/espatcontrol_simpletest.py
@@ -35,6 +35,6 @@ while True:
         print("Pinging 8.8.8.8...", end="")
         print(esp.ping("8.8.8.8"))
         time.sleep(10)
-    except (RuntimeError, adafruit_espatcontrol.OKError) as e:
+    except (ValueError,RuntimeError, adafruit_espatcontrol.OKError) as e:
         print("Failed to get data, retrying\n", e)
         continue

--- a/examples/espatcontrol_webclient.py
+++ b/examples/espatcontrol_webclient.py
@@ -41,6 +41,6 @@ while True:
         print("Text:", r.text)
 
         time.sleep(60)
-    except (RuntimeError, adafruit_espatcontrol.OKError) as e:
+    except (ValueError, RuntimeError, adafruit_espatcontrol.OKError) as e:
         print("Failed to get data, retrying\n", e)
         continue


### PR DESCRIPTION
fix import in countviewer example, add ValueError to Execption trap in examples.
the imports need to be "from adafruit_espcontrol import ..."
some errors result in ValueError -- report failure but continue retrying.