### PR TITLE
import either json or ujson

### DIFF
--- a/adafruit_espatcontrol/adafruit_espatcontrol_requests.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_requests.py
@@ -62,8 +62,11 @@ class Response:
 
     def json(self):
         """The HTTP content, parsed into a json dictionary"""
-        import ujson
-        return ujson.loads(self.content)
+        try:
+            import json as json_module
+        except ImportError:
+            import ujson as json_module
+        return json_module.loads(self.content)
 
 
 # pylint: disable=too-many-branches, too-many-statements, unused-argument, too-many-arguments, too-many-locals
@@ -115,8 +118,11 @@ def request(method, url, data=None, json=None, headers=None, stream=None):
             sock.write(b"\r\n")
         if json is not None:
             assert data is None
-            import ujson
-            data = ujson.dumps(json)
+            try:
+                import json as json_module
+            except ImportError:
+                import ujson as json_module
+            data = json_module.dumps(json)
             sock.write(b"Content-Type: application/json\r\n")
         if data:
             sock.write(b"Content-Length: %d\r\n" % len(data))

--- a/examples/espatcontrol_quoteEPD.py
+++ b/examples/espatcontrol_quoteEPD.py
@@ -11,7 +11,10 @@ import busio
 from digitalio import DigitalInOut
 from adafruit_espatcontrol import adafruit_espatcontrol
 from adafruit_espatcontrol import adafruit_espatcontrol_requests as requests
-import ujson
+try:
+    import json as json_module
+except ImportError:
+    import ujson as json_module
 from adafruit_epd.epd import Adafruit_EPD
 from adafruit_epd.il0373 import Adafruit_IL0373
 
@@ -56,7 +59,7 @@ def get_value(response, location):
     """Extract a value from a json object, based on the path in 'location'"""
     try:
         print("Parsing JSON response...", end='')
-        json = ujson.loads(response)
+        json = json_module.loads(response)
         print("parsed OK!")
         for x in location:
             json = json[x]


### PR DESCRIPTION
We're renaming `ujson` to `json` in 4.0.0. Tries to import json parser as either `json` or `ujson` for upward compatibility. Renames import to `json_module` to avoid conflicts with variables named `json`.