### PR TITLE
 increase CWLAP timeout, modify simpletest to fix AP Scan

### DIFF
--- a/adafruit_espatcontrol/adafruit_espatcontrol.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol.py
@@ -450,7 +450,7 @@ class ESP_ATcontrol:
             try:
                 if self.mode != self.MODE_STATION:
                     self.mode = self.MODE_STATION
-                scan = self.at_response("AT+CWLAP", timeout=3).split(b'\r\n')
+                scan = self.at_response("AT+CWLAP", timeout=5).split(b'\r\n')
             except RuntimeError:
                 continue
             routers = []

--- a/examples/espatcontrol_webclient.py
+++ b/examples/espatcontrol_webclient.py
@@ -15,11 +15,13 @@ except ImportError:
 # With a Metro or Feather M4
 uart = busio.UART(board.TX, board.RX, timeout=0.1)
 resetpin = DigitalInOut(board.D5)
+rtspin = DigitalInOut(board.D6)
 
 # With a Particle Argon
 """
 uart = busio.UART(board.ESP_RX, board.ESP_TX, timeout=0.1)
 resetpin = DigitalInOut(board.ESP_WIFI_EN)
+rtspin = DigitalInOut(board.ESP_CTS)
 esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
 from digitalio import Direction
 esp_boot.direction = Direction.OUTPUT
@@ -29,8 +31,8 @@ esp_boot.value = True
 URL = "http://wifitest.adafruit.com/testwifi/index.html"
 print("ESP AT GET URL", URL)
 
-esp = adafruit_espatcontrol.ESP_ATcontrol(uart, 115200, run_baudrate=9600,
-                                          reset_pin=resetpin, debug=False)
+esp = adafruit_espatcontrol.ESP_ATcontrol(uart, 115200,
+                                          reset_pin=resetpin, rts_pin=rtspin, debug=False)
 print("Resetting ESP module")
 esp.hard_reset()
 


### PR DESCRIPTION
the ESP32 was timinng out when receiving the AP scan -- increasing timeout to 5 seconds seems to fix it. also the ESP32 seems to magically reconnect to the last AP even after a hard reset. I changed the simpletest to force an AP scan and reconnect.
Tested with 8266 on particle xenon and ESP32 on particle argon

also left initial baudrates for simpletest and webclient at default 115200 and use rts_pin.