### PR TITLE
Fix compatibility issue with the latest adafruit_requests.py library

### DIFF
--- a/adafruit_espatcontrol/adafruit_espatcontrol.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol.py
@@ -283,6 +283,7 @@ class ESP_ATcontrol:
                         bundle.append(self._ipdpacket[0:i])
                         gc.collect()
                         i = incoming_bytes = 0
+                        break  # We've received all the data. Don't wait until timeout.
             else:  # no data waiting
                 self.hw_flow(True)  # start the floooow
         totalsize = sum([len(x) for x in bundle])
@@ -408,7 +409,7 @@ class ESP_ATcontrol:
         reply = self.at_response('AT+CIPDOMAIN="%s"' % host.strip('"'), timeout=3)
         for line in reply.split(b"\r\n"):
             if line and line.startswith(b"+CIPDOMAIN:"):
-                return str(line[11:], "utf-8")
+                return str(line[11:], "utf-8").strip('"')
         raise RuntimeError("Couldn't find IP address")
 
     # *************************** AP SETUP ****************************

--- a/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
@@ -49,7 +49,7 @@ class socket:
         host, port = address
         
         # Determine the conntype from port if not specified.
-        if conntype == None:
+        if conntype is None:
             if port == 80:
                 conntype = "TCP"
             elif port == 443:

--- a/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
@@ -47,14 +47,14 @@ class socket:
         """Connect the socket to the 'address' (which should be dotted quad IP). 'conntype'
         is an extra that may indicate SSL or not, depending on the underlying interface"""
         host, port = address
-        
+
         # Determine the conntype from port if not specified.
         if conntype is None:
             if port == 80:
                 conntype = "TCP"
             elif port == 443:
                 conntype = "SSL"
-                
+
         if not _the_interface.socket_connect(
             conntype, host, port, keepalive=10, retries=3
         ):
@@ -82,8 +82,10 @@ class socket:
             ret = self._buffer + _the_interface.socket_receive(timeout=self._timeout)
             self._buffer = b""
         else:
-            if (self._buffer == b""):
-                self._buffer = self._buffer + _the_interface.socket_receive(timeout=self._timeout)
+            if self._buffer == b"":
+                self._buffer = self._buffer + _the_interface.socket_receive(
+                    timeout=self._timeout
+                )
             ret = self._buffer[:num]
             self._buffer = self._buffer[num:]
         return ret

--- a/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
@@ -47,6 +47,14 @@ class socket:
         """Connect the socket to the 'address' (which should be dotted quad IP). 'conntype'
         is an extra that may indicate SSL or not, depending on the underlying interface"""
         host, port = address
+        
+        # Determine the conntype from port if not specified.
+        if conntype == None:
+            if port == 80:
+                conntype = "TCP"
+            elif port == 443:
+                conntype = "SSL"
+                
         if not _the_interface.socket_connect(
             conntype, host, port, keepalive=10, retries=3
         ):
@@ -74,6 +82,8 @@ class socket:
             ret = self._buffer + _the_interface.socket_receive(timeout=self._timeout)
             self._buffer = b""
         else:
+            if (self._buffer == b""):
+                self._buffer = self._buffer + _the_interface.socket_receive(timeout=self._timeout)
             ret = self._buffer[:num]
             self._buffer = self._buffer[num:]
         return ret


### PR DESCRIPTION
I know there is no longer support for ESP AT Control using UART. But this pull request fixed some bugs and tested working with Espressif AT Firmware v2.2.0.