### PR TITLE
Read larger chunks to avoid loosing data.

### DIFF
--- a/adafruit_espatcontrol/adafruit_espatcontrol.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol.py
@@ -523,7 +523,7 @@ class ESP_ATcontrol:
             response = b""
             while (time.monotonic() - stamp) < timeout:
                 if self._uart.in_waiting:
-                    response += self._uart.read(1)
+                    response += self._uart.read(self._uart.in_waiting)
                     self.hw_flow(False)
                     if response[-4:] == b"OK\r\n":
                         break


### PR DESCRIPTION
When receiving large amounts of data we would sometimes loose information here and there. By reading all available data from the uart this problem has been solved.