### PR TITLE
Revert "Read larger chunks to avoid losing data."

### DIFF
--- a/adafruit_espatcontrol/adafruit_espatcontrol.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol.py
@@ -523,7 +523,7 @@ class ESP_ATcontrol:
             response = b""
             while (time.monotonic() - stamp) < timeout:
                 if self._uart.in_waiting:
-                    response += self._uart.read(self._uart.in_waiting)
+                    response += self._uart.read(1)
                     self.hw_flow(False)
                     if response[-4:] == b"OK\r\n":
                         break


### PR DESCRIPTION
Reverts adafruit/Adafruit_CircuitPython_ESP_ATcontrol#41
This pull request can cause OK, or ERROR markers to be missed. I need to think about this a little longer.