### PR TITLE
Adding Support for Challenger 2040 WiFi boards. 

### DIFF
--- a/examples/esp_atcontrol_aio_post.py
+++ b/examples/esp_atcontrol_aio_post.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+# Note, you must create a feed called "test" in your AdafruitIO account.
+# Your secrets file must contain your aio_username and aio_key
+
 import time
 import board
 import busio
@@ -21,21 +24,34 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
+# Debug Level
+# Change the Debug Flag if you have issues with AT commands    
+debugflag=False
 
-# With a Particle Argon
-RX = board.ESP_TX
-TX = board.ESP_RX
-resetpin = DigitalInOut(board.ESP_WIFI_EN)
-rtspin = DigitalInOut(board.ESP_CTS)
-uart = busio.UART(TX, RX, timeout=0.1)
-esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
-esp_boot.direction = Direction.OUTPUT
-esp_boot.value = True
-status_light = None
+if board.board_id == "challenger_rp2040_wifi":
+    RX = board.ESP_RX
+    TX = board.ESP_TX
+    resetpin = DigitalInOut(board.WIFI_RESET)
+    rtspin = False
+    uart = busio.UART(TX, RX, baudrate=11520)
+    esp_boot = DigitalInOut(board.WIFI_MODE)
+    esp_boot.direction = Direction.OUTPUT
+    esp_boot.value = True
+    status_light = None
+else:
+    RX = board.ESP_TX
+    TX = board.ESP_RX
+    resetpin = DigitalInOut(board.ESP_WIFI_EN)
+    rtspin = DigitalInOut(board.ESP_CTS)
+    uart = busio.UART(TX, RX, timeout=0.1)
+    esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
+    esp_boot.direction = Direction.OUTPUT
+    esp_boot.value = True
+    status_light = None
 
 print("ESP AT commands")
 esp = adafruit_espatcontrol.ESP_ATcontrol(
-    uart, 115200, reset_pin=resetpin, rts_pin=rtspin, debug=False
+    uart, 115200, reset_pin=resetpin, rts_pin=rtspin, debug=debugflag
 )
 wifi = adafruit_espatcontrol_wifimanager.ESPAT_WiFiManager(esp, secrets, status_light)
 

--- a/examples/esp_atcontrol_aio_post.py
+++ b/examples/esp_atcontrol_aio_post.py
@@ -25,8 +25,8 @@ except ImportError:
     raise
 
 # Debug Level
-# Change the Debug Flag if you have issues with AT commands    
-debugflag=False
+# Change the Debug Flag if you have issues with AT commands
+debugflag = False
 
 if board.board_id == "challenger_rp2040_wifi":
     RX = board.ESP_RX

--- a/examples/esp_atcontrol_simpletest.py
+++ b/examples/esp_atcontrol_simpletest.py
@@ -52,8 +52,9 @@ first_pass = True
 while True:
     try:
         if first_pass:
-# Some ESP do not return OK on AP Scan. See https://github.com/adafruit/Adafruit_CircuitPython_ESP_ATcontrol/issues/48
-# disable next 3 lines if you get a No OK response to AT+CWLAP
+# Some ESP do not return OK on AP Scan. 
+# See https://github.com/adafruit/Adafruit_CircuitPython_ESP_ATcontrol/issues/48
+# Comment out the next 3 lines if you get a No OK response to AT+CWLAP
             print("Scanning for AP's")
             for ap in esp.scan_APs():
                 print(ap)

--- a/examples/esp_atcontrol_simpletest.py
+++ b/examples/esp_atcontrol_simpletest.py
@@ -1,4 +1,3 @@
-
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
@@ -17,8 +16,8 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 # Debug Level
-# Change the Debug Flag if you have issues with AT commands    
-debugflag=False
+# Change the Debug Flag if you have issues with AT commands
+debugflag = False
 
 if board.board_id == "challenger_rp2040_wifi":
     RX = board.ESP_RX
@@ -52,9 +51,9 @@ first_pass = True
 while True:
     try:
         if first_pass:
-# Some ESP do not return OK on AP Scan. 
-# See https://github.com/adafruit/Adafruit_CircuitPython_ESP_ATcontrol/issues/48
-# Comment out the next 3 lines if you get a No OK response to AT+CWLAP
+            # Some ESP do not return OK on AP Scan.
+            # See https://github.com/adafruit/Adafruit_CircuitPython_ESP_ATcontrol/issues/48
+            # Comment out the next 3 lines if you get a No OK response to AT+CWLAP
             print("Scanning for AP's")
             for ap in esp.scan_APs():
                 print(ap)

--- a/examples/esp_atcontrol_simpletest.py
+++ b/examples/esp_atcontrol_simpletest.py
@@ -17,15 +17,24 @@ except ImportError:
     raise
 
 
-# With a Particle Argon
-RX = board.ESP_TX
-TX = board.ESP_RX
-resetpin = DigitalInOut(board.WIFI_RESET)
-rtspin = DigitalInOut(board.ESP_CTS)
-uart = busio.UART(TX, RX, timeout=0.1)
-esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
-esp_boot.direction = Direction.OUTPUT
-esp_boot.value = True
+if board.board_id == challenger_rp2040_wifi:
+    RX = board.ESP_TX
+    TX = board.ESP_RX
+    resetpin = DigitalInOut(board.WIFI_RESET)
+    rtspin = DigitalInOut(board.ESP_CTS)
+    uart = busio.UART(TX, RX, timeout=0.1)
+    esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
+    esp_boot.direction = Direction.OUTPUT
+    esp_boot.value = True
+else:
+    RX = board.ESP_TX
+    TX = board.ESP_RX
+    resetpin = DigitalInOut(board.ESP_WIFI_EN)
+    rtspin = DigitalInOut(board.ESP_CTS)
+    uart = busio.UART(TX, RX, timeout=0.1)
+    esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
+    esp_boot.direction = Direction.OUTPUT
+    esp_boot.value = True
 
 
 print("ESP AT commands")

--- a/examples/esp_atcontrol_simpletest.py
+++ b/examples/esp_atcontrol_simpletest.py
@@ -20,7 +20,7 @@ except ImportError:
 # With a Particle Argon
 RX = board.ESP_TX
 TX = board.ESP_RX
-resetpin = DigitalInOut(board.ESP_WIFI_EN)
+resetpin = DigitalInOut(board.WIFI_RESET)
 rtspin = DigitalInOut(board.ESP_CTS)
 uart = busio.UART(TX, RX, timeout=0.1)
 esp_boot = DigitalInOut(board.ESP_BOOT_MODE)

--- a/examples/esp_atcontrol_simpletest.py
+++ b/examples/esp_atcontrol_simpletest.py
@@ -17,7 +17,7 @@ except ImportError:
     raise
 
 
-if board.board_id == challenger_rp2040_wifi:
+if board.board_id == "challenger_rp2040_wifi":
     RX = board.ESP_TX
     TX = board.ESP_RX
     resetpin = DigitalInOut(board.WIFI_RESET)

--- a/examples/esp_atcontrol_simpletest.py
+++ b/examples/esp_atcontrol_simpletest.py
@@ -1,3 +1,4 @@
+
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
@@ -18,11 +19,11 @@ except ImportError:
 
 
 if board.board_id == "challenger_rp2040_wifi":
-    RX = board.ESP_TX
-    TX = board.ESP_RX
+    RX = board.ESP_RX
+    TX = board.ESP_TX
     resetpin = DigitalInOut(board.WIFI_RESET)
-#   rtspin = DigitalInOut(board.ESP_CTS)
-    uart = busio.UART(board.ESP_TX, board.ESP_RX, baudrate=11520)
+    rtspin = False
+    uart = busio.UART(TX, RX, baudrate=11520)
     esp_boot = DigitalInOut(board.WIFI_MODE)
     esp_boot.direction = Direction.OUTPUT
     esp_boot.value = True
@@ -40,7 +41,7 @@ else:
 print("ESP AT commands")
 # I had to remove the rtspin from the esp bellow to get the challenger_rp2040_wifi to work.
 esp = adafruit_espatcontrol.ESP_ATcontrol(
-    uart, 115200, reset_pin=resetpin, debug=False
+    uart, 115200, reset_pin=resetpin, rts_pin=rtspin, debug=False
 )
 print("Resetting ESP module")
 esp.hard_reset()

--- a/examples/esp_atcontrol_simpletest.py
+++ b/examples/esp_atcontrol_simpletest.py
@@ -16,7 +16,9 @@ try:
 except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
-
+# Debug Level
+# Change the Debug Flag if you have issues with AT commands    
+debugflag=False
 
 if board.board_id == "challenger_rp2040_wifi":
     RX = board.ESP_RX
@@ -39,9 +41,9 @@ else:
 
 
 print("ESP AT commands")
-# I had to remove the rtspin from the esp bellow to get the challenger_rp2040_wifi to work.
+# For Boards that do not have an rtspin like challenger_rp2040_wifi set rtspin to False.
 esp = adafruit_espatcontrol.ESP_ATcontrol(
-    uart, 115200, reset_pin=resetpin, rts_pin=rtspin, debug=False
+    uart, 115200, reset_pin=resetpin, rts_pin=rtspin, debug=debugflag
 )
 print("Resetting ESP module")
 esp.hard_reset()
@@ -50,10 +52,11 @@ first_pass = True
 while True:
     try:
         if first_pass:
-# I had to comment out scanning for APs as that did not work
-#            print("Scanning for AP's")
-#            for ap in esp.scan_APs():
-#                print(ap)
+# Some ESP do not return OK on AP Scan. See https://github.com/adafruit/Adafruit_CircuitPython_ESP_ATcontrol/issues/48
+# disable next 3 lines if you get a No OK response to AT+CWLAP
+            print("Scanning for AP's")
+            for ap in esp.scan_APs():
+                print(ap)
             print("Checking connection...")
             # secrets dictionary must contain 'ssid' and 'password' at a minimum
             print("Connecting...")

--- a/examples/esp_atcontrol_simpletest.py
+++ b/examples/esp_atcontrol_simpletest.py
@@ -16,14 +16,14 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-# the default else is the Aragon settings. Add different inits for different boards. 
+
 if board.board_id == "challenger_rp2040_wifi":
     RX = board.ESP_TX
     TX = board.ESP_RX
     resetpin = DigitalInOut(board.WIFI_RESET)
-    rtspin = DigitalInOut(board.ESP_CTS)
-    uart = busio.UART(TX, RX, timeout=0.1)
-    esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
+#   rtspin = DigitalInOut(board.ESP_CTS)
+    uart = busio.UART(board.ESP_TX, board.ESP_RX, baudrate=11520)
+    esp_boot = DigitalInOut(board.WIFI_MODE)
     esp_boot.direction = Direction.OUTPUT
     esp_boot.value = True
 else:
@@ -38,8 +38,9 @@ else:
 
 
 print("ESP AT commands")
+# I had to remove the rtspin from the esp bellow to get the challenger_rp2040_wifi to work.
 esp = adafruit_espatcontrol.ESP_ATcontrol(
-    uart, 115200, reset_pin=resetpin, rts_pin=rtspin, debug=False
+    uart, 115200, reset_pin=resetpin, debug=False
 )
 print("Resetting ESP module")
 esp.hard_reset()
@@ -48,9 +49,10 @@ first_pass = True
 while True:
     try:
         if first_pass:
-            print("Scanning for AP's")
-            for ap in esp.scan_APs():
-                print(ap)
+# I had to comment out scanning for APs as that did not work
+#            print("Scanning for AP's")
+#            for ap in esp.scan_APs():
+#                print(ap)
             print("Checking connection...")
             # secrets dictionary must contain 'ssid' and 'password' at a minimum
             print("Connecting...")

--- a/examples/esp_atcontrol_simpletest.py
+++ b/examples/esp_atcontrol_simpletest.py
@@ -16,7 +16,7 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-
+# the default else is the Aragon settings. Add different inits for different boards. 
 if board.board_id == "challenger_rp2040_wifi":
     RX = board.ESP_TX
     TX = board.ESP_RX


### PR DESCRIPTION
The current setup/init logic for this library is focused on the Particle Aragon.  I added a If block to the examples with the default logic being the Particle (else) and (if board.board_id == "challenger_rp2040_wifi") being for the challenger.  Should make it easier for adding other boards as well.

I moved the debug setting to a variable that is set in the early code.

For the Challenger boards I am getting some errors on AT commands not always sending back an expected OK.  Have opened issue in Adafruit_CircuitPython_ESP_ATcontrol AT+CWLAP Does not return OK #48

I have also added a few comment lines that I think will help people.  In aiocontrol_simpletest,  I added a reminder that you need to create the feed in adafruitio, and what additional entries you need in the secrets file.  In atcontrol_simpletest I added comments that the AP scan may fail and which lines to comment out if that is breaking (goes back to the opened issue).