### PR TITLE
Fixes for "in Adafruit_CircuitPython_ESP_ATcontrol AT+CWLAP Does not return OK #48"

### DIFF
--- a/examples/esp_atcontrol_aio_post.py
+++ b/examples/esp_atcontrol_aio_post.py
@@ -33,7 +33,7 @@ if board.board_id == "challenger_rp2040_wifi":
     TX = board.ESP_TX
     resetpin = DigitalInOut(board.WIFI_RESET)
     rtspin = False
-    uart = busio.UART(TX, RX, baudrate=11520)
+    uart = busio.UART(TX, RX, baudrate=11520, receiver_buffer_size=2048)
     esp_boot = DigitalInOut(board.WIFI_MODE)
     esp_boot.direction = Direction.OUTPUT
     esp_boot.value = True

--- a/examples/esp_atcontrol_cheerlights.py
+++ b/examples/esp_atcontrol_cheerlights.py
@@ -1,3 +1,4 @@
+
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
@@ -24,21 +25,38 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
+# Debug Level
+# Change the Debug Flag if you have issues with AT commands
+debugflag = False
 
-# With a Particle Argon
-RX = board.ESP_TX
-TX = board.ESP_RX
-resetpin = DigitalInOut(board.ESP_WIFI_EN)
-rtspin = DigitalInOut(board.ESP_CTS)
-uart = busio.UART(TX, RX, timeout=0.1)
-esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
-esp_boot.direction = Direction.OUTPUT
-esp_boot.value = True
-status_light = None
+if board.board_id == "challenger_rp2040_wifi":
+    RX = board.ESP_RX
+    TX = board.ESP_TX
+    resetpin = DigitalInOut(board.WIFI_RESET)
+    rtspin = False
+    uart = busio.UART(TX, RX, baudrate=11520, receiver_buffer_size=2048)
+    esp_boot = DigitalInOut(board.WIFI_MODE)
+    esp_boot.direction = Direction.OUTPUT
+    esp_boot.value = True
+    status_light = None
+    pixel_pin = board.NEOPIXEL
+    num_pixels = 1
+else:
+    RX = board.ESP_TX
+    TX = board.ESP_RX
+    resetpin = DigitalInOut(board.ESP_WIFI_EN)
+    rtspin = DigitalInOut(board.ESP_CTS)
+    uart = busio.UART(TX, RX, timeout=0.1)
+    esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
+    esp_boot.direction = Direction.OUTPUT
+    esp_boot.value = True
+    status_light = None
+    pixel_pin = board.A1
+    num_pixels = 16
 
 print("ESP AT commands")
 esp = adafruit_espatcontrol.ESP_ATcontrol(
-    uart, 115200, reset_pin=resetpin, rts_pin=rtspin, debug=False
+    uart, 115200, reset_pin=resetpin, rts_pin=rtspin, debug=debugflag
 )
 wifi = adafruit_espatcontrol_wifimanager.ESPAT_WiFiManager(esp, secrets, status_light)
 
@@ -47,8 +65,8 @@ DATA_SOURCE = "https://api.thingspeak.com/channels/1417/feeds.json?results=1"
 DATA_LOCATION = ["feeds", 0, "field2"]
 
 
-# neopixels
-pixels = neopixel.NeoPixel(board.A1, 16, brightness=0.3)
+# Setup and Clear neopixels
+pixels = neopixel.NeoPixel(pixel_pin, num_pixels, brightness=0.3)
 pixels.fill(0)
 
 # we'll save the value in question
@@ -77,7 +95,7 @@ while True:
         green = color >> 8 & 0xFF
         blue = color & 0xFF
         gamma_corrected = fancy.gamma_adjust(fancy.CRGB(red, green, blue)).pack()
-
+        print('Setting LED To: G:{0},R:{1},B:{2},Gamma:{3}'.format(green, red, blue, gamma_corrected))
         pixels.fill(gamma_corrected)
         last_value = value
     response = None

--- a/examples/esp_atcontrol_cheerlights.py
+++ b/examples/esp_atcontrol_cheerlights.py
@@ -1,4 +1,3 @@
-
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
@@ -95,7 +94,11 @@ while True:
         green = color >> 8 & 0xFF
         blue = color & 0xFF
         gamma_corrected = fancy.gamma_adjust(fancy.CRGB(red, green, blue)).pack()
-        print('Setting LED To: G:{0},R:{1},B:{2},Gamma:{3}'.format(green, red, blue, gamma_corrected))
+        print(
+            "Setting LED To: G:{0},R:{1},B:{2},Gamma:{3}".format(
+                green, red, blue, gamma_corrected
+            )
+        )
         pixels.fill(gamma_corrected)
         last_value = value
     response = None

--- a/examples/esp_atcontrol_countviewer.py
+++ b/examples/esp_atcontrol_countviewer.py
@@ -147,10 +147,9 @@ def chime_light():
                 pass
     if NEOPIXELS_ON_CHANGE:
         for i in range(100, 0, -10):
-            for i in range(0, 100, 10):
-                if pixel_type == "RGB/GRB":
-                    pixels.fill((i, i, i))
-                elif pixel_type == "RGBW/GRBW":
+            if pixel_type == "RGB/GRB":
+                pixels.fill((i, i, i))
+            elif pixel_type == "RGBW/GRBW":
                     pixels.fill((i, i, i, i))
             pixels.show()
             time.sleep(1)

--- a/examples/esp_atcontrol_countviewer.py
+++ b/examples/esp_atcontrol_countviewer.py
@@ -199,4 +199,3 @@ while True:
     print("GC MEM:{0}".format(gc.mem_free()))  # pylint: disable=no-member
     print("Sleeping for: {0} Seconds".format(TIME_BETWEEN_QUERY))
     time.sleep(TIME_BETWEEN_QUERY)
-

--- a/examples/esp_atcontrol_countviewer.py
+++ b/examples/esp_atcontrol_countviewer.py
@@ -150,7 +150,7 @@ def chime_light():
             if pixel_type == "RGB/GRB":
                 pixels.fill((i, i, i))
             elif pixel_type == "RGBW/GRBW":
-                    pixels.fill((i, i, i, i))
+                pixels.fill((i, i, i, i))
             pixels.show()
             time.sleep(1)
         pixels.fill(0)

--- a/examples/esp_atcontrol_countviewer.py
+++ b/examples/esp_atcontrol_countviewer.py
@@ -27,7 +27,8 @@ except ImportError:
 
 #              CONFIGURATION
 PLAY_SOUND_ON_CHANGE = False
-NEOPIXELS_ON_CHANGE = False
+NEOPIXELS_ON_CHANGE = True
+DISPLAY_ATTACHED = False
 TIME_BETWEEN_QUERY = 60  # in seconds
 
 # Some data sources and JSON locations to try out
@@ -63,17 +64,36 @@ DATA_LOCATION = ["bpi", "USD", "rate_float"]
 # "screen_names=adafruit"
 # DATA_LOCATION = [0, "followers_count"]
 
+# Debug Level
+# Change the Debug Flag if you have issues with AT commands
+debugflag = False
 
-# With a Particle Argon
-RX = board.ESP_TX
-TX = board.ESP_RX
-resetpin = DigitalInOut(board.ESP_WIFI_EN)
-rtspin = DigitalInOut(board.ESP_CTS)
-uart = busio.UART(TX, RX, timeout=0.1)
-esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
-esp_boot.direction = Direction.OUTPUT
-esp_boot.value = True
-
+if board.board_id == "challenger_rp2040_wifi":
+    RX = board.ESP_RX
+    TX = board.ESP_TX
+    resetpin = DigitalInOut(board.WIFI_RESET)
+    rtspin = False
+    uart = busio.UART(TX, RX, baudrate=11520, receiver_buffer_size=2048)
+    esp_boot = DigitalInOut(board.WIFI_MODE)
+    esp_boot.direction = Direction.OUTPUT
+    esp_boot.value = True
+    status_light = None
+    pixel_pin = board.NEOPIXEL
+    num_pixels = 1
+    pixel_type = "RGBW/GRBW"
+else:
+    RX = board.ESP_TX
+    TX = board.ESP_RX
+    resetpin = DigitalInOut(board.ESP_WIFI_EN)
+    rtspin = DigitalInOut(board.ESP_CTS)
+    uart = busio.UART(TX, RX, timeout=0.1)
+    esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
+    esp_boot.direction = Direction.OUTPUT
+    esp_boot.value = True
+    status_light = None
+    pixel_pin = board.A1
+    num_pixels = 16
+    pixel_type = "RGB/GRB"
 
 # Create the connection to the co-processor and reset
 esp = adafruit_espatcontrol.ESP_ATcontrol(
@@ -82,17 +102,20 @@ esp = adafruit_espatcontrol.ESP_ATcontrol(
 esp.hard_reset()
 
 requests.set_socket(socket, esp)
-
-# Create the I2C interface.
-i2c = busio.I2C(board.SCL, board.SDA)
-# Attach a 7 segment display and display -'s so we know its not live yet
-display = segments.Seg7x4(i2c)
-display.print("----")
+# display
+if DISPLAY_ATTACHED:
+    # Create the I2C interface.
+    i2c = busio.I2C(board.SCL, board.SDA)
+    # Attach a 7 segment display and display -'s so we know its not live yet
+    display = segments.Seg7x4(i2c)
+    display.print("----")
 
 # neopixels
 if NEOPIXELS_ON_CHANGE:
-    pixels = neopixel.NeoPixel(board.A1, 16, brightness=0.4, pixel_order=(1, 0, 2, 3))
-    pixels.fill(0)
+    pixels = neopixel.NeoPixel(
+        pixel_pin, num_pixels, brightness=0.4, pixel_order=(1, 0, 2, 3)
+    )
+    pixels.fill(20)
 
 # music!
 if PLAY_SOUND_ON_CHANGE:
@@ -111,7 +134,12 @@ def chime_light():
     """Light up LEDs and play a tune"""
     if NEOPIXELS_ON_CHANGE:
         for i in range(0, 100, 10):
-            pixels.fill((i, i, i))
+            if pixel_type == "RGB/GRB":
+                pixels.fill((i, i, i))
+            elif pixel_type == "RGBW/GRBW":
+                pixels.fill((i, i, i, i))
+            pixels.show()
+            time.sleep(1)
     if PLAY_SOUND_ON_CHANGE:
         with audioio.AudioOut(board.A0) as audio:
             audio.play(wave)
@@ -119,7 +147,13 @@ def chime_light():
                 pass
     if NEOPIXELS_ON_CHANGE:
         for i in range(100, 0, -10):
-            pixels.fill((i, i, i))
+            for i in range(0, 100, 10):
+                if pixel_type == "RGB/GRB":
+                    pixels.fill((i, i, i))
+                elif pixel_type == "RGBW/GRBW":
+                    pixels.fill((i, i, i, i))
+            pixels.show()
+            time.sleep(1)
         pixels.fill(0)
 
 
@@ -148,8 +182,11 @@ while True:
         value = value[x]
     if not value:
         continue
-    print(times, the_time, "value:", value)
-    display.print(int(value))
+    print("Times:{0}. The Time:{1}. Value: {2}".format(times, the_time, value))
+    if DISPLAY_ATTACHED:
+        display.print(int(value))
+    else:
+        print("INT Value:{0}".format(int(value)))
 
     if last_value != value:
         chime_light()  # animate the neopixels
@@ -159,5 +196,7 @@ while True:
     # normally we wouldn't have to do this, but we get bad fragments
     r = value = None
     gc.collect()
-    print(gc.mem_free())  # pylint: disable=no-member
+    print("GC MEM:{0}".format(gc.mem_free()))  # pylint: disable=no-member
+    print("Sleeping for: {0} Seconds".format(TIME_BETWEEN_QUERY))
     time.sleep(TIME_BETWEEN_QUERY)
+

--- a/examples/esp_atcontrol_localtime.py
+++ b/examples/esp_atcontrol_localtime.py
@@ -96,4 +96,3 @@ while True:
     print(time.localtime())
     print("Sleeping for: {0} Seconds".format(sleep_duration))
     time.sleep(sleep_duration)
-

--- a/examples/esp_atcontrol_localtime.py
+++ b/examples/esp_atcontrol_localtime.py
@@ -21,22 +21,38 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
+# Debug Level
+# Change the Debug Flag if you have issues with AT commands
+debugflag = False
 
-# With a Particle Argon
-RX = board.ESP_TX
-TX = board.ESP_RX
-resetpin = DigitalInOut(board.ESP_WIFI_EN)
-rtspin = DigitalInOut(board.ESP_CTS)
-uart = busio.UART(TX, RX, timeout=0.1)
-esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
-esp_boot.direction = Direction.OUTPUT
-esp_boot.value = True
-status_light = None
+# How Long to sleep between polling
+sleep_duration = 5
 
+if board.board_id == "challenger_rp2040_wifi":
+    RX = board.ESP_RX
+    TX = board.ESP_TX
+    resetpin = DigitalInOut(board.WIFI_RESET)
+    rtspin = False
+    uart = busio.UART(TX, RX, baudrate=11520, receiver_buffer_size=2048)
+    esp_boot = DigitalInOut(board.WIFI_MODE)
+    esp_boot.direction = Direction.OUTPUT
+    esp_boot.value = True
+    status_light = None
+
+else:
+    RX = board.ESP_TX
+    TX = board.ESP_RX
+    resetpin = DigitalInOut(board.ESP_WIFI_EN)
+    rtspin = DigitalInOut(board.ESP_CTS)
+    uart = busio.UART(TX, RX, timeout=0.1)
+    esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
+    esp_boot.direction = Direction.OUTPUT
+    esp_boot.value = True
+    status_light = None
 
 print("ESP AT commands")
 esp = adafruit_espatcontrol.ESP_ATcontrol(
-    uart, 115200, reset_pin=resetpin, rts_pin=rtspin, debug=False
+    uart, 115200, reset_pin=resetpin, rts_pin=rtspin, debug=debugflag
 )
 wifi = adafruit_espatcontrol_wifimanager.ESPAT_WiFiManager(esp, secrets, status_light)
 
@@ -78,4 +94,6 @@ the_rtc.datetime = now
 
 while True:
     print(time.localtime())
-    time.sleep(1)
+    print("Sleeping for: {0} Seconds".format(sleep_duration))
+    time.sleep(sleep_duration)
+

--- a/examples/esp_atcontrol_simpletest.py
+++ b/examples/esp_atcontrol_simpletest.py
@@ -24,7 +24,7 @@ if board.board_id == "challenger_rp2040_wifi":
     TX = board.ESP_TX
     resetpin = DigitalInOut(board.WIFI_RESET)
     rtspin = False
-    uart = busio.UART(TX, RX, baudrate=11520)
+    uart = busio.UART(TX, RX, baudrate=11520, receiver_buffer_size=2048)
     esp_boot = DigitalInOut(board.WIFI_MODE)
     esp_boot.direction = Direction.OUTPUT
     esp_boot.value = True

--- a/examples/esp_atcontrol_webclient.py
+++ b/examples/esp_atcontrol_webclient.py
@@ -18,21 +18,37 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
+# Debug Level
+# Change the Debug Flag if you have issues with AT commands
+debugflag = False
 
-# With a Particle Argon
-RX = board.ESP_TX
-TX = board.ESP_RX
-resetpin = DigitalInOut(board.ESP_WIFI_EN)
-rtspin = DigitalInOut(board.ESP_CTS)
-uart = busio.UART(TX, RX, timeout=0.1)
-esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
-esp_boot.direction = Direction.OUTPUT
-esp_boot.value = True
+# How long between queries
+TIME_BETWEEN_QUERY = 60  # in seconds
 
+if board.board_id == "challenger_rp2040_wifi":
+    RX = board.ESP_RX
+    TX = board.ESP_TX
+    resetpin = DigitalInOut(board.WIFI_RESET)
+    rtspin = False
+    uart = busio.UART(TX, RX, baudrate=11520, receiver_buffer_size=2048)
+    esp_boot = DigitalInOut(board.WIFI_MODE)
+    esp_boot.direction = Direction.OUTPUT
+    esp_boot.value = True
+    status_light = None
+else:
+    RX = board.ESP_TX
+    TX = board.ESP_RX
+    resetpin = DigitalInOut(board.ESP_WIFI_EN)
+    rtspin = DigitalInOut(board.ESP_CTS)
+    uart = busio.UART(TX, RX, timeout=0.1)
+    esp_boot = DigitalInOut(board.ESP_BOOT_MODE)
+    esp_boot.direction = Direction.OUTPUT
+    esp_boot.value = True
+    status_light = None
 
 print("ESP AT commands")
 esp = adafruit_espatcontrol.ESP_ATcontrol(
-    uart, 115200, reset_pin=resetpin, rts_pin=rtspin, debug=False
+    uart, 115200, reset_pin=resetpin, rts_pin=rtspin, debug=debugflag
 )
 
 URL = "http://wifitest.adafruit.com/testwifi/index.html"
@@ -57,8 +73,8 @@ while True:
         print("Content size:", r.headers["content-length"])
         print("Encoding:", r.encoding)
         print("Text:", r.text)
-
-        time.sleep(60)
+        print("Sleeping for: {0} Seconds".format(TIME_BETWEEN_QUERY))
+        time.sleep(TIME_BETWEEN_QUERY)
     except (ValueError, RuntimeError, adafruit_espatcontrol.OKError) as e:
         print("Failed to get data, retrying\n", e)
         continue


### PR DESCRIPTION

Fixes for "in Adafruit_CircuitPython_ESP_ATcontrol AT+CWLAP Does not return OK #48".  or at least a workaround.  Buffer is defined for Challenger RP2040 WiFi Boards that keeps it from overrunning CP.

All the examples now have a if/elif for the Challenger 2040 WiFi boards, and all the examples now run!

Other small changes to add cleaner output formatting, A variable for debug level, and other small tweaks.. 