### PR TITLE
Update adafruit_espatcontrol_socket.py

### DIFF
--- a/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
@@ -73,6 +73,9 @@ class socket:
                 conntype = "TCP"
             elif port == 443:
                 conntype = "SSL"
+            #to cater for MQTT over TCP
+            elif port == 1883
+                conntype = "TCP"
 
         if not _the_interface.socket_connect(
             conntype, host, port, keepalive=10, retries=3

--- a/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
@@ -74,7 +74,7 @@ class socket:
             elif port == 443:
                 conntype = "SSL"
             #to cater for MQTT over TCP
-            elif port == 1883
+            elif port == 1883:
                 conntype = "TCP"
 
         if not _the_interface.socket_connect(

--- a/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
@@ -73,7 +73,7 @@ class socket:
                 conntype = "TCP"
             elif port == 443:
                 conntype = "SSL"
-            #to cater for MQTT over TCP
+            # to cater for MQTT over TCP
             elif port == 1883:
                 conntype = "TCP"
 


### PR DESCRIPTION
I got error when using adafruit_espatcontrol_socket.py and  adafruit_minimqtt  when I use port 1883 for MQTT, it is due to connection type is not defined for port 1883

Traceback (most recent call last):
  File "code.py", line 117, in <module>
  File "/lib/adafruit_minimqtt/adafruit_minimqtt.py", line 447, in connect
  File "/lib/adafruit_minimqtt/adafruit_minimqtt.py", line 270, in _get_connect_socket
  File "/lib/adafruit_espatcontrol/adafruit_espatcontrol_socket.py", line 85, in connect
  File "/lib/adafruit_espatcontrol/adafruit_espatcontrol.py", line 202, in socket_connect
RuntimeError: Connection type must be TCP, UDL or SSL

I propose to add conntype TCP for port 1883 in the condition