### PR TITLE
Swap import orders

### DIFF
--- a/adafruit_espatcontrol/adafruit_espatcontrol.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol.py
@@ -37,8 +37,8 @@ import time
 from digitalio import Direction, DigitalInOut
 
 try:
-    import busio
     from typing import Optional, Dict, Union, List
+    import busio
 except ImportError:
     pass
 

--- a/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_socket.py
@@ -6,8 +6,8 @@
 from micropython import const
 
 try:
-    from .adafruit_espatcontrol import ESP_ATcontrol
     from typing import Optional, Tuple, List
+    from .adafruit_espatcontrol import ESP_ATcontrol
 except ImportError:
     pass
 

--- a/adafruit_espatcontrol/adafruit_espatcontrol_wifimanager.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_wifimanager.py
@@ -17,8 +17,8 @@ import adafruit_requests as requests
 import adafruit_espatcontrol.adafruit_espatcontrol_socket as socket
 
 try:
-    from adafruit_espatcontrol.adafruit_espatcontrol import ESP_ATcontrol
     from typing import Dict, Protocol, Any, Optional, Union, Tuple
+    from adafruit_espatcontrol.adafruit_espatcontrol import ESP_ATcontrol
 
     class Pixel(Protocol):
         """


### PR DESCRIPTION
As is, some imports were happen before the `typing` import guard in the `try`/`except` block kicked in.  This moves imports so they won't actually import.