### PR TITLE
Fix import of Protocol in adafruit_espatcontrol_wifimanager.py

### DIFF
--- a/adafruit_espatcontrol/adafruit_espatcontrol_wifimanager.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_wifimanager.py
@@ -18,6 +18,7 @@ import adafruit_espatcontrol.adafruit_espatcontrol_socket as socket
 
 try:
     from typing import Dict, Any, Optional, Union, Tuple
+
     try:
         from typing import Protocol
     except ImportError:

--- a/adafruit_espatcontrol/adafruit_espatcontrol_wifimanager.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_wifimanager.py
@@ -18,7 +18,12 @@ import adafruit_espatcontrol.adafruit_espatcontrol_socket as socket
 
 try:
     from adafruit_espatcontrol.adafruit_espatcontrol import ESP_ATcontrol
-    from typing import Dict, Protocol, Any, Optional, Union, Tuple
+    from typing import Dict, Any, Optional, Union, Tuple
+
+    try:
+        from typing import Protocol
+    except ImportError:
+        from typing_extensions import Protocol
 
     class Pixel(Protocol):
         """


### PR DESCRIPTION
Allows for import of `Protocol` in Python 3.7, which has it in `typing_extensions`