### PR TITLE
Use circuitpython_typing.FillBasedLED instead of custom Pixel protocol

### DIFF
--- a/adafruit_espatcontrol/adafruit_espatcontrol_wifimanager.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_wifimanager.py
@@ -18,27 +18,7 @@ import adafruit_espatcontrol.adafruit_espatcontrol_socket as socket
 
 try:
     from typing import Dict, Any, Optional, Union, Tuple
-
-    try:
-        from typing import Protocol
-    except ImportError:
-        from typing_extensions import Protocol
-    from adafruit_espatcontrol.adafruit_espatcontrol import ESP_ATcontrol
-
-    class Pixel(Protocol):
-        """
-        A class for providing type hints for parameters
-        requiring a pixel device (NeoPixel/DotStar)
-        """
-
-        def fill(  # pylint: disable=unused-argument, no-self-use
-            self, value: Union[int, Tuple[int, int, int]]
-        ) -> Any:
-            """
-            Duck types out the fill method for pixel devices
-            """
-            ...
-
+    from circuitpython_typing.led import FillBasedLED
 except ImportError:
     pass
 
@@ -52,7 +32,7 @@ class ESPAT_WiFiManager:
         self,
         esp: ESP_ATcontrol,
         secrets: Dict[str, Union[str, int]],
-        status_pixel: Optional[Pixel] = None,
+        status_pixel: Optional[FillBasedLED] = None,
         attempts: int = 2,
     ):
         """

--- a/adafruit_espatcontrol/adafruit_espatcontrol_wifimanager.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol_wifimanager.py
@@ -19,6 +19,7 @@ import adafruit_espatcontrol.adafruit_espatcontrol_socket as socket
 try:
     from typing import Dict, Any, Optional, Union, Tuple
     from circuitpython_typing.led import FillBasedLED
+    from adafruit_espatcontrol.adafruit_espatcontrol import ESP_ATcontrol
 except ImportError:
     pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
+adafruit-circuitpython-typing
 pyserial

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
-adafruit-circuitpython-typing
+adafruit-circuitpython-typing>=1.4.0
 pyserial

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,11 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka", "pyserial"],
+    install_requires=[
+        "Adafruit-Blinka",
+        "adafruit-circuitpython-typing>=1.4.0",
+        "pyserial",
+    ],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Pins to `circuitpython_typing` minimum release that adds this functionality