### PR TITLE
Increase depreciation header line length

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Introduction
     :alt: Build Status
 
 This library is no longer supported! The library is being left available for continued usage, however, Adafruit is no longer supporting it.
-=============
+===========================================================================================================================================
 
 Use the ESP AT command sent to communicate with the Interwebs. Its slow, but works to get data into CircuitPython
 


### PR DESCRIPTION
Fixes build CI failure found while searching for libraries with failed CI results from the `.pre-commit-config.yaml` patch