### PR TITLE
Consolidate retry-logic

### DIFF
--- a/adafruit_espatcontrol/adafruit_espatcontrol.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol.py
@@ -147,7 +147,7 @@ class ESP_ATcontrol:
             AP = self.remote_AP  # pylint: disable=invalid-name
             if AP[0] != secrets["ssid"]:
                 self.join_AP(secrets["ssid"], secrets["password"],timeout=timeout, retries=retries)
-                print("Connected to", AP[0])
+                print("Connected to", secrets["ssid"])
                 if "timezone" in secrets:
                     tzone = secrets["timezone"]
                     ntp = None
@@ -155,6 +155,8 @@ class ESP_ATcontrol:
                         ntp = secrets["ntp_server"]
                     self.sntp_config(True, tzone, ntp)
                 print("My IP Address:", self.local_ip)
+            else:
+                print("Already connected to", AP[0])
             return  # yay!
         except (RuntimeError, OKError) as exp:
             print("Failed to connect\n", exp)

--- a/adafruit_espatcontrol/adafruit_espatcontrol.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol.py
@@ -467,9 +467,9 @@ class ESP_ATcontrol:
             return reply
         return [None] * 4
 
-    def join_AP(
+    def join_AP(  # pylint: disable=invalid-name
         self, ssid: str, password: str, timeout: int = 15, retries: int = 3
-    ) -> None:  # pylint: disable=invalid-name
+    ) -> None:
         """Try to join an access point by name and password, will return
         immediately if we're already connected and won't try to reconnect"""
         # First make sure we're in 'station' mode so we can connect to AP's

--- a/adafruit_espatcontrol/adafruit_espatcontrol.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol.py
@@ -462,7 +462,7 @@ class ESP_ATcontrol:
             return reply
         return [None] * 4
 
-    def join_AP(self, ssid: str, password: str) -> None:  # pylint: disable=invalid-name
+    def join_AP(self, ssid: str, password: str, timeout: int = 15, retries: int = 3) -> None:  # pylint: disable=invalid-name
         """Try to join an access point by name and password, will return
         immediately if we're already connected and won't try to reconnect"""
         # First make sure we're in 'station' mode so we can connect to AP's
@@ -474,7 +474,7 @@ class ESP_ATcontrol:
             return  # we're already connected!
         for _ in range(3):
             reply = self.at_response(
-                'AT+CWJAP="' + ssid + '","' + password + '"', timeout=15, retries=3
+                'AT+CWJAP="' + ssid + '","' + password + '"', timeout=timeout, retries=retries
             )
             if b"WIFI CONNECTED" not in reply:
                 print("no CONNECTED")

--- a/adafruit_espatcontrol/adafruit_espatcontrol.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol.py
@@ -472,17 +472,16 @@ class ESP_ATcontrol:
         router = self.remote_AP
         if router and router[0] == ssid:
             return  # we're already connected!
-        for _ in range(3):
-            reply = self.at_response(
-                'AT+CWJAP="' + ssid + '","' + password + '"', timeout=timeout, retries=retries
-            )
-            if b"WIFI CONNECTED" not in reply:
-                print("no CONNECTED")
-                raise RuntimeError("Couldn't connect to WiFi")
-            if b"WIFI GOT IP" not in reply:
-                print("no IP")
-                raise RuntimeError("Didn't get IP address")
-            return
+        reply = self.at_response(
+            'AT+CWJAP="' + ssid + '","' + password + '"', timeout=timeout, retries=retries
+        )
+        if b"WIFI CONNECTED" not in reply:
+            print("no CONNECTED")
+            raise RuntimeError("Couldn't connect to WiFi")
+        if b"WIFI GOT IP" not in reply:
+            print("no IP")
+            raise RuntimeError("Didn't get IP address")
+        return
 
     def scan_APs(  # pylint: disable=invalid-name
         self, retries: int = 3

--- a/adafruit_espatcontrol/adafruit_espatcontrol.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol.py
@@ -135,7 +135,9 @@ class ESP_ATcontrol:
             except OKError:
                 pass  # retry
 
-    def connect(self, secrets: Dict[str, Union[str, int]], timeout: int = 15, retries: int = 3) -> None:
+    def connect(
+        self, secrets: Dict[str, Union[str, int]], timeout: int = 15, retries: int = 3
+    ) -> None:
         """Repeatedly try to connect to an access point with the details in
         the passed in 'secrets' dictionary. Be sure 'ssid' and 'password' are
         defined in the secrets dict! If 'timezone' is set, we'll also configure
@@ -146,7 +148,12 @@ class ESP_ATcontrol:
                 self.begin()
             AP = self.remote_AP  # pylint: disable=invalid-name
             if AP[0] != secrets["ssid"]:
-                self.join_AP(secrets["ssid"], secrets["password"],timeout=timeout, retries=retries)
+                self.join_AP(
+                    secrets["ssid"],
+                    secrets["password"],
+                    timeout=timeout,
+                    retries=retries,
+                )
                 print("Connected to", secrets["ssid"])
                 if "timezone" in secrets:
                     tzone = secrets["timezone"]
@@ -460,7 +467,9 @@ class ESP_ATcontrol:
             return reply
         return [None] * 4
 
-    def join_AP(self, ssid: str, password: str, timeout: int = 15, retries: int = 3) -> None:  # pylint: disable=invalid-name
+    def join_AP(
+        self, ssid: str, password: str, timeout: int = 15, retries: int = 3
+    ) -> None:  # pylint: disable=invalid-name
         """Try to join an access point by name and password, will return
         immediately if we're already connected and won't try to reconnect"""
         # First make sure we're in 'station' mode so we can connect to AP's
@@ -471,7 +480,9 @@ class ESP_ATcontrol:
         if router and router[0] == ssid:
             return  # we're already connected!
         reply = self.at_response(
-            'AT+CWJAP="' + ssid + '","' + password + '"', timeout=timeout, retries=retries
+            'AT+CWJAP="' + ssid + '","' + password + '"',
+            timeout=timeout,
+            retries=retries,
         )
         if b"WIFI CONNECTED" not in reply:
             print("no CONNECTED")
@@ -575,7 +586,12 @@ class ESP_ATcontrol:
             # special case, ping also does not return an OK
             if "AT+PING" in at_cmd and b"ERROR\r\n" in response:
                 return response
-            if response[-4:] != b"OK\r\n":
+            # special case, does return OK but in fact it is busy
+            if (
+                "AT+CIFSR" in at_cmd
+                and b"busy" in response
+                or response[-4:] != b"OK\r\n"
+            ):
                 time.sleep(1)
                 continue
             return response[:-4]

--- a/adafruit_espatcontrol/adafruit_espatcontrol.py
+++ b/adafruit_espatcontrol/adafruit_espatcontrol.py
@@ -158,6 +158,7 @@ class ESP_ATcontrol:
             return  # yay!
         except (RuntimeError, OKError) as exp:
             print("Failed to connect\n", exp)
+            raise
 
     # *************************** SOCKET SETUP ****************************
 


### PR DESCRIPTION
This patch  fixes #61 by

- adding retries and timeout-parameters to all levels of the software-stack
- pushing timeout/retries from top to bottom
- executing retry-loop only from `at_response`

The number of retries can now be controlled at application-level, the user of the library can decide if she needs many retries or prefers fast failing.

The patches also gets rid of a number of loops that either never did what they should do or which were never executed anyhow.